### PR TITLE
Fixe

### DIFF
--- a/TVServerXBMC/TV/ServerInterface.cs
+++ b/TVServerXBMC/TV/ServerInterface.cs
@@ -965,7 +965,7 @@ namespace MPTvClient
                         // that is deleted in the meantime
                         recInfo.channel = rec.IdChannel.ToString();
                     }
-                    recInfo.title = rec.Title;
+                    recInfo.title = rec.EpisodeName.Length>0 ? rec.EpisodeName:rec.Title;
                     recInfo.description = rec.Description;
                     recInfo.genre = rec.Genre;
                     recInfo.timeInfo = rec.StartTime.ToString("u") + "|" + rec.EndTime.ToString("u");
@@ -994,6 +994,7 @@ namespace MPTvClient
                 {
                     string recording;
                     string channelname;
+                    string title;
                     string rtspURL = GetRecordingURL(rec.IdRecording, server, resolveHostnames, ref OriginalURL);//server.GetStreamUrlForFileName(rec.IdRecording);
 
                     //XBMC pvr side:
@@ -1029,12 +1030,12 @@ namespace MPTvClient
                         // that is deleted in the meantime
                         channelname = rec.IdChannel.ToString();
                     }
-
+                    title = rec.EpisodeName.Length > 0 ? rec.EpisodeName : rec.Title;
                     recording = rec.IdRecording.ToString() + "|"  // 0
                         + rec.StartTime.ToString("u") + "|"       // 1
                         + rec.EndTime.ToString("u") + "|"         // 2
                         + channelname.Replace("|", "") + "|"      // 3
-                        + rec.Title.Replace("|","") + "|"         // 4
+                        + title.Replace("|","") + "|"         // 4
                         + rec.Description.Replace("|", "") + "|"  // 5
                         + rtspURL + "|"                           // 6
                         + rec.FileName + "|"                      // 7
@@ -1223,6 +1224,9 @@ namespace MPTvClient
                     String strEndTime;
                     String strIdChannel;
                     String strProgramName;
+         
+                    if (sched.IdParentSchedule != -1) //If it has a parent it's a recording of a serie we won't use this.
+                        continue;
 
                     //XBMC pvr side:
                     //
@@ -1258,26 +1262,36 @@ namespace MPTvClient
                     strEndTime = sched.EndTime.ToString("u");
                     strIdChannel = sched.IdChannel.ToString();
                     strProgramName = sched.ProgramName;
-
                     try
                     {
-                      IList<Program> progs = Schedule.GetProgramsForSchedule(sched);
-                      if (progs.Count > 0) //Currently xbmc use the last occurence of each program has the next recording, when fixe we should return all resolved program.
-                      {
-                        Program pr = progs[0];
-                        strStartTime = pr.StartTime.ToString("u");
-                        strEndTime = pr.EndTime.ToString("u");
-                        strIdChannel = pr.IdChannel.ToString();
-                        strProgramName = pr.Title;
-                        if (pr.EpisodeName.Length>0)
-                          strProgramName += " - " + pr.EpisodeName;
-                        if (pr.IsRecording)
-                          strIsRecording = "True";
-                      }
+                        IList<Program> progs = Schedule.GetProgramsForSchedule(sched);
+                        if (progs.Count > 0) //Currently xbmc use the last occurence of each program has the next recording, when fixe we should return all resolved program.
+                        {
+                            Program pr = progs[0];
+                            strStartTime = pr.StartTime.ToString("u");
+                            strEndTime = pr.EndTime.ToString("u");
+                            strIdChannel = pr.IdChannel.ToString();
+                            strProgramName = pr.Title;
+                            if (pr.EpisodeName.Length > 0)
+                                strProgramName += " - " + pr.EpisodeName;
+                            if (pr.IsRecording)
+                                strIsRecording = "True";
+                        }
+                        else if((ScheduleRecordingType)sched.ScheduleType!=(ScheduleRecordingType.Once))
+                        {
+                            continue; //This timer does not resolve to a program. Do not return it until we have a state for it in XBMC.
+                        }
+                        else //IF the schedule did not resolve to any program, typical when creating an Instant Recording frm XBMC and the name does not match a program name.
+                        {
+                            VirtualCard card;
+                            TvControl.TvServer tv = new TvServer();
+                            if(tv.IsRecordingSchedule(sched.IdSchedule, out card))
+                                strIsRecording = "True";
+                        }
                     }
                     catch
                     { }
-
+                    
                     schedule = sched.IdSchedule.ToString() + "|"
                         + strStartTime + "|"
                         + strEndTime + "|"


### PR DESCRIPTION
1-Having the episode title is nicer than just the program name. Ideally we would have to add the episode name in xbmc FileItem so it would be available in the view. I prefer this imperfect solution to the current situation but feel free to leave it has before.

2- Properly handle Schedule not resolving to a program. (Has when the season is finish).
3- Properly handle Instant recording not having a program name that match the one in the EPG.

Thank's

oh by the way I will send other PR to opdenkamp and then those this PR will me more usefull. (Currently recording and Next recording working properly on the home screen).
