### PR TITLE
Update GetEPG.cs

### DIFF
--- a/TVServerKodi/Commands/GetEPG.cs
+++ b/TVServerKodi/Commands/GetEPG.cs
@@ -55,7 +55,7 @@ namespace TVServerKodi.Commands
                                 + e.IdProgram.ToString() + "|"
                                 + e.IdChannel.ToString() + "|"
                                 + e.SeriesNum + "|"
-                                + e.EpisodeNumber + "|"
+                                + e.EpisodeNum + "|"
                                 + e.EpisodeName + "|"
                                 + e.EpisodePart + "|"
                                 + e.OriginalAirDate.ToString("u") + "|"


### PR DESCRIPTION
Hi Marcel,
when i look at my epg*.db of Kodi, the columns "iSeriesId" and "iEpisodeId" always have the same number (the seriesnumber).
I see you are referring everywhere "EpisodeNumber", but in my TVServer MySQL database it is "episodeNum"!

Don't know if there's other code you have to adapt, but this was the one found via web...

Bye!
pünktchen