### PR TITLE
Extend return message format of "IsTimeshifting" command

### DIFF
--- a/TVServerKodi/Commands/IsTimeshifting.cs
+++ b/TVServerKodi/Commands/IsTimeshifting.cs
@@ -17,12 +17,13 @@ namespace TVServerKodi.Commands
          */
         public override void handleCommand(string command, string[] arguments, ref TvControl.IUser me)
         {
-            string rtspUrl = TVServerConnection.getTimeshiftUrl(ref me);
+            TimeShiftURLs timeShiftURLs = TVServerConnection.getTimeshiftURLs(ref me);
             bool result = true;
-            if (String.IsNullOrEmpty(rtspUrl))
+
+            if (timeShiftURLs == null || String.IsNullOrEmpty(timeShiftURLs.RTSPUrl) || String.IsNullOrEmpty(timeShiftURLs.TimeShiftFileName))
             {
+                timeShiftURLs = new TimeShiftURLs { RTSPUrl = "", TimeShiftFileName = "" };
                 result = false;
-                rtspUrl = "";
             }
 
             // results = isShifting;url;chanInfo as in ListChannels
@@ -33,8 +34,8 @@ namespace TVServerKodi.Commands
                 c = TVServerConnection.getTimeshiftInfo(ref me);
             }
 
-            writer.write(writer.makeItemSmart(result.ToString(), rtspUrl, c));
-            
+            writer.write(writer.makeItemSmart(result.ToString(), timeShiftURLs.RTSPUrl, timeShiftURLs.TimeShiftFileName, c));
+
         }
 
         public override string getCommandToHandle()

--- a/TVServerKodi/TV/ServerInterface.cs
+++ b/TVServerKodi/TV/ServerInterface.cs
@@ -18,7 +18,7 @@ namespace TVServerKodi
         IController controller = null;
 
         IUser me = null;
-        Dictionary<String, String> isTimeShifting = null;
+        Dictionary<String, TimeShiftURLs> isTimeShifting = null;
         public static Dictionary<String, TvControl.User> userlist = null;
         public Exception lastException = null;
 
@@ -27,7 +27,7 @@ namespace TVServerKodi
         public TVServerController(IController controller)
         {
             this.controller = controller;
-            this.isTimeShifting = new Dictionary<String,String>();
+            this.isTimeShifting = new Dictionary<String, TimeShiftURLs>();
             TVServerController.userlist = new Dictionary<String, TvControl.User>();
         }
 
@@ -102,7 +102,7 @@ namespace TVServerKodi
 
                 try
                 {
-                    isTimeShifting.Add(user.Name, rtspURL);
+                    isTimeShifting.Add(user.Name, new TimeShiftURLs { RTSPUrl = rtspURL, TimeShiftFileName = timeshiftfilename });
                 }
                 catch { }
 
@@ -165,16 +165,16 @@ namespace TVServerKodi
             return result;
         }
 
-        public string GetTimeshiftUrl(ref TvControl.IUser me)
+        public TimeShiftURLs GetTimeshiftURLs(ref TvControl.IUser me)
         {
             if (IsTimeShifting(ref me))
             {
-                string url;
-                if ( isTimeShifting.TryGetValue(me.Name, out url) )
-                    return url;
+                TimeShiftURLs timeShiftURLs = new TimeShiftURLs();
+                if (isTimeShifting.TryGetValue(me.Name, out timeShiftURLs))
+                    return timeShiftURLs;
             }
 
-            return "";
+            return null;
         }
 
         public bool IsTimeShifting(ref IUser user)
@@ -191,7 +191,7 @@ namespace TVServerKodi
                     {   //Found one...
                         user.CardId = ss.cardId;
                         user.IdChannel = ss.channelId;
-                        isTimeShifting.Add(user.Name, ss.RTSPUrl);
+                        isTimeShifting.Add(user.Name, new TimeShiftURLs { RTSPUrl = ss.RTSPUrl, TimeShiftFileName = ss.TimeShiftFileName });
                         TVServerController.userlist[user.Name].CardId = ss.cardId;
                         TVServerController.userlist[user.Name].IdChannel = ss.channelId;
                         return true;

--- a/TVServerKodi/TV/Utils.cs
+++ b/TVServerKodi/TV/Utils.cs
@@ -22,6 +22,11 @@ namespace TVServerKodi
     public string TimeShiftFileName;
     public string userName;
   }
+  public class TimeShiftURLs
+  {
+    public string RTSPUrl;
+    public string TimeShiftFileName;
+  }
   public class ProgrammInfo
   {
     public string timeInfo;

--- a/TVServerKodi/TVServerConnection.cs
+++ b/TVServerKodi/TVServerConnection.cs
@@ -293,9 +293,9 @@ namespace TVServerKodi
             return result;
         }
 
-        public static string getTimeshiftUrl(ref TvControl.IUser me)
+        public static TimeShiftURLs getTimeshiftURLs(ref TvControl.IUser me)
         {
-            return serverIntf.GetTimeshiftUrl(ref me);
+            return serverIntf.GetTimeshiftURLs(ref me);
         }
 
         public static ChannelInfo getTimeshiftInfo(ref TvControl.IUser me)


### PR DESCRIPTION
Hi,

I have extended return message format of "IsTimeshifting" command , timeshift file path added to the message. 

Current return message format: "True|rtsp://HostName:554/stream5.2|ChannelInfo"
New return message format: "True|rtsp://HostName:554/stream5.2|\\\\HOSTNAME-PC\\Timeshift\\live5-2.ts.tsbuffer|ChannelInfo"
 
This modification will allow me to pass UNC timeshift file to DirectShow source filter of [Kodi DSPlayer](http://forum.kodi.tv/showthread.php?tid=223175&pid=2015166#pid2015166).

I have verified that this changes will not affect the existing functionality of pvr.mediaportal.tvserver addon.

Roman